### PR TITLE
Update README.md to show correct usage of the dom-repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,9 @@ triggered property.
 
 ```html
 <iron-scroll-threshold on-lower-threshold="loadMoreData">
-  <dom-repeat items="[[items]]">
-    <template>
+  <template is="dom-repeat" items="[[items]]">
       <div>[[index]]</div>
-    </template>
-  </dom-repeat>
+  </template>
 </iron-scroll-threshold>
 ```
 


### PR DESCRIPTION
In the `README.md`, dom-repeat is incorrectly represented in a matter that doesn't work (being a type-extension), accidentally being written in a matter that's only correct for `iron-list` with its usage of `template` prior to writing the markup to be repeated.

The `README.md` is now corrected to demonstrate the correct usage of `dom-repeat` that otherwise would severely confuse or cognitively block consumers less experienced with its usage & Polymer idioms
## Recommended reviewers

@arthurevans, being aware of his general oversight of such things. 
