### PR TITLE
Bugfix: Scrolling isn't smooth on iPhone

### DIFF
--- a/iron-scroll-threshold.html
+++ b/iron-scroll-threshold.html
@@ -159,6 +159,8 @@ triggered property.
 
     _setOverflow: function(scrollTarget) {
       this.style.overflow = scrollTarget === this ? 'auto' : '';
+      // Enable smooth momentum-based scrolling on iOS
+      this.style['-webkit-overflow-scrolling'] = scrollTarget === this ? 'touch' : '';
     },
 
     _scrollHandler: function() {


### PR DESCRIPTION
Scrolling an area in iron-scroll-treshold on iPhone wasn't feeling smooth because iron-scroll-treshold didn't instruct Safari to use momentum-based scrolling.

Fixes https://github.com/PolymerElements/iron-scroll-threshold/issues/8
