### PR TITLE
Remove deprecated and unused version field

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "web-components",
     "polymer"
   ],
-  "version": "1.0.2",
   "homepage": "https://github.com/PolymerElements/iron-scroll-threshold",
   "authors": [
     "The Polymer Authors"


### PR DESCRIPTION
The version field in bower.json is deprecated and ignored by bower. Keeping it here can lead to confusion when git tags and this field disagree.

See also https://github.com/bower/spec/blob/master/json.md#version